### PR TITLE
Double-init issue

### DIFF
--- a/src/spooky.erl
+++ b/src/spooky.erl
@@ -39,11 +39,14 @@ start(Modules) when is_list(Modules)->
 start([Module|T], Handlers, Middlewares)->
     ?LOG_INFO("Starting spooky with ~p", [Module]),
     % The first module's options are the ones for misultin
-    Opts = apply(Module, init, [[]]),
-    
-    Opts0 = proplists:delete(handlers, Opts),
-    ?LOG_INFO("Options ~p", [Opts]),
-    start([Module|T], Handlers, Middlewares, Opts0).
+    ModuleOpts = apply(Module, init, [[]]),
+
+    ModuleHandlers = lookup(handlers, ModuleOpts, [Module]),
+    ModuleMiddlewares = lookup(middlewares, ModuleOpts, []),
+
+    Opts = proplists:delete(handlers, ModuleOpts),
+    ?LOG_INFO("Options ~p", [ModuleOpts]),
+    start(T, Handlers ++ ModuleHandlers, Middlewares ++ ModuleMiddlewares, Opts).
 
 start([Module|T], Handlers, Middlewares, Opts)->
     % Accumulate all the handlers and middlewares

--- a/src/spooky.erl
+++ b/src/spooky.erl
@@ -39,22 +39,14 @@ start(Modules) when is_list(Modules)->
 start([Module|T], Handlers, Middlewares)->
     ?LOG_INFO("Starting spooky with ~p", [Module]),
     % The first module's options are the ones for misultin
-    ModuleOpts = apply(Module, init, [[]]),
-
-    ModuleHandlers = lookup(handlers, ModuleOpts, [Module]),
-    ModuleMiddlewares = lookup(middlewares, ModuleOpts, []),
-
+    {ModuleOpts, ModuleHandlers, ModuleMiddlewares} = init_module(Module),
     Opts = proplists:delete(handlers, ModuleOpts),
     ?LOG_INFO("Options ~p", [ModuleOpts]),
     start(T, Handlers ++ ModuleHandlers, Middlewares ++ ModuleMiddlewares, Opts).
 
 start([Module|T], Handlers, Middlewares, Opts)->
     % Accumulate all the handlers and middlewares
-    ModuleOpts = apply(Module, init, [[]]),
-    
-    ModuleHandlers = lookup(handlers, ModuleOpts, [Module]),
-    ModuleMiddlewares = lookup(middlewares, ModuleOpts, []),
-    
+    {_, ModuleHandlers, ModuleMiddlewares} = init_module(Module),
     start(T, Handlers ++ ModuleHandlers, Middlewares ++ ModuleMiddlewares, Opts);
 
 start([], Handlers, Middlewares, Opts)->
@@ -92,6 +84,16 @@ behaviour_info(callbacks)->
     [{init, 1}];
 behaviour_info(_Other)->
     undefined.
+
+
+%%
+%% Utility methods
+%%
+init_module(Module) ->
+    Opts = apply(Module, init, [[]]),
+    Handlers = lookup(handlers, Opts, [Module]),
+    Middlewares = lookup(middlewares, Opts, []),
+    {Opts, Handlers, Middlewares}.
 
 lookup(Key, Opts, Default)->
     case proplists:lookup(Key, Opts) of


### PR DESCRIPTION
Hi!

I ran into a problem with Spooky because I had an init/1 method with side-effects (it was spawning and registering a process). It turns out that the first module's init/1 was being called in both spooky:start/3 and start/4. I reworked start/3 so it doesn't rely on start/4 to process the first module. I know that leads to a few lines of duplicated code, but I couldn't see a cleaner way to do it.

But even with this hiccup, Spooky has been so much easier to get going with than other frameworks. Thanks for creating it!

-Colin
